### PR TITLE
ignore non-OpenStack Rackspace products

### DIFF
--- a/keystone_rxt/rackspace.py
+++ b/keystone_rxt/rackspace.py
@@ -223,6 +223,7 @@ class RXTv2Credentials(object):
                 [
                     i["name"].split(":")[-1]
                     for i in service_catalog["access"]["user"]["roles"]
+                    if access_token["tenant"]["id"] in i.get("tenantId", "")
                 ]
             )
             self._set_federation_env(


### PR DESCRIPTION
The Rackspace service catalog returns roles for non-OpenStack products that Rackspace offers. These do not using the same types of values or mappings that OpenStack uses which causes an issue. They aren't something that would be supported in keystone anyway since they exist outside of identity for roles and permissions so ignore them from this plugin.