### PR TITLE
feat: update keystone-rxt to use the new rxt role

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,24 @@ jobs:
 
     strategy:
       matrix:
-        openstack: [2023.1, 2023.2, 2024.1]
-        distro: [ubuntu_jammy]
+        openstack:
+          - 2023.1
+          - 2023.2
+          - 2024.1
+        distro:
+          - ubuntu_jammy
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Dynamically set MY_DATE environment variable
+        run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -44,8 +54,11 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
+          context: .
           push: true
-          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.openstack }}-${{ matrix.distro }}"
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.openstack }}-${{ matrix.distro }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.openstack }}-${{ matrix.distro }}-${{ env.MY_DATE }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
 ARG VERSION=master-ubuntu_jammy
-FROM openstackhelm/keystone:$VERSION
-RUN /var/lib/openstack/bin/pip install --no-cache-dir keystone-rxt
+FROM openstackhelm/keystone:${VERSION} as build
+RUN apt update && apt install -y git
+RUN /var/lib/openstack/bin/pip install --upgrade --force-reinstall pip
+WORKDIR /opt/keystone-rxt
+COPY . /opt/keystone-rxt
+RUN ls -al /opt/keystone-rxt/
+RUN /var/lib/openstack/bin/pip install --no-cache-dir -e git+file:///opt/keystone-rxt#egg=keystone-rxt
+RUN find /var/lib/openstack -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
+
+FROM openstackhelm/keystone:${VERSION}
+COPY --from=build /var/lib/openstack/. /var/lib/openstack/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The configuration file entry will look something like this
 methods = password,token,application_credential
 password = rxt
 ```
+
 > Take note that the `password` method is defined and that the password plugin is set to use `rxt`.
 
 If you have multifactor auth enabled, and want to support users that are running work loads with it
@@ -71,8 +72,18 @@ password = rxt
 totp = rxt
 ```
 
-Yes, effectively one line is all that's required in config (maybe two with totp support). After the
-configuration edit, be sure to restart keystone.
+Yes, just a couple of lines is all that's required in config. After the configuration edit, be sure to restart
+keystone.
+
+#### Rackspace Configurations
+
+The `[rackspace]` section can also be used in your `keystone.conf` to allow you to configure how to anchor on
+roles.
+
+| key               | value |
+| ----------------- | ----- |
+| `role_attribute` | A string option used as an anchor to discover roles attributed to a given user |
+| `role_attribute_enforcement` | When set `true` will limit a users project to only the discovered GUID for the defined `role_attribute` |
 
 ### Identity mapping, project, and domain setup
 
@@ -94,7 +105,7 @@ openstack identity provider create --remote-id rackspace --domain rackspace_clou
 ##### Create the mapping for our identity provider
 
 ``` shell
-openstack mapping create --rules files/mapping.json rackspace_mapping
+openstack mapping create --rules files/mapping.json --schema-version 2.0 rackspace_mapping
 ```
 
 ##### Create the federation protocol

--- a/files/mapping.json
+++ b/files/mapping.json
@@ -4,32 +4,28 @@
             {
                 "user": {
                     "name": "{0}",
-                    "email": "{1}"
+                    "email": "{1}",
+                    "domain": {
+                        "name": "rackspace_cloud_domain"
+                    }
                 }
             },
             {
                 "projects": [
                     {
-                        "name": "{2}_Production",
+                        "name": "{2}",
+                        "domain": {
+                            "name": "rackspace_cloud_domain"
+                        },
                         "roles": [
                             {
                                 "name": "member"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "{2}_Staging",
-                        "roles": [
+                            },
                             {
-                                "name": "member"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "{2}_Development",
-                        "roles": [
+                                "name": "load-balancer_member"
+                            },
                             {
-                                "name": "member"
+                                "name": "heat_stack_user"
                             }
                         ]
                     }
@@ -49,119 +45,9 @@
             {
                 "type": "RXT_orgPersonType",
                 "any_one_of": [
-                    "admin"
-                ]
-            }
-        ]
-    },
-    {
-        "local": [
-            {
-                "user": {
-                    "name": "{0}",
-                    "email": "{1}"
-                }
-            },
-            {
-                "projects": [
-                    {
-                        "name": "{2}_Production",
-                        "roles": [
-                            {
-                                "name": "reader"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "{2}_Staging",
-                        "roles": [
-                            {
-                                "name": "member"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "{2}_Development",
-                        "roles": [
-                            {
-                                "name": "member"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ],
-        "remote": [
-            {
-                "type": "RXT_UserName"
-            },
-            {
-                "type": "RXT_Email"
-            },
-            {
-                "type": "RXT_TenantName"
-            },
-            {
-                "type": "RXT_orgPersonType",
-                "not_any_of": [
-                    "admin"
-                ]
-            }
-        ]
-    },
-    {
-        "local": [
-            {
-                "user": {
-                    "name": "{0}",
-                    "email": "{1}"
-                }
-            },
-            {
-                "projects": [
-                    {
-                        "name": "{2}_Production",
-                        "roles": [
-                            {
-                                "name": "reader"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "{2}_Staging",
-                        "roles": [
-                            {
-                                "name": "reader"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "{2}_Development",
-                        "roles": [
-                            {
-                                "name": "reader"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ],
-        "remote": [
-            {
-                "type": "RXT_UserName"
-            },
-            {
-                "type": "RXT_Email"
-            },
-            {
-                "type": "RXT_TenantName"
-            },
-            {
-                "type": "RXT_orgPersonType",
-                "not_any_of": [
                     "admin",
-                    "creator",
                     "default",
+                    "user-admin",
                     "tenant-access"
                 ]
             }

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,12 +30,6 @@ domain = keystone
 [entry_points]
 keystone.auth.password =
     rxt = keystone_rxt.rackspace:RXTPassword
+
 keystone.auth.totp =
     rxt = keystone_rxt.rackspace:RXTTOTP
-
-[options.packages.find]
-where = files
-
-[options.package_data]
-* =
-  *.txt


### PR DESCRIPTION
This change makes it possible to run the keystone rxt plugin in
an environment using the os_flex attribute.

This change includes
* multi-account detection and autoprovisioning
* new mapping defaults for scheme version 2.0

Two new options have been added to support the creation of the
role attribute methods, allowing a user to be a member of more
than one project.

[rackspace]
role_attribute_enforcement <BOOL>
role_attribute <STR>