### PR TITLE
feat: add fine-grain rbac from RXT

### DIFF
--- a/files/mapping.json
+++ b/files/mapping.json
@@ -29,20 +29,7 @@
                                 "project_tag": "{3}"
                             }
                         ],
-                        "roles": [
-                            {
-                                "name": "member"
-                            },
-                            {
-                                "name": "load-balancer_member"
-                            },
-                            {
-                                "name": "heat_stack_user"
-                            },
-                            {
-                                "name": "creator"
-                            }
-                        ]
+                        "roles": []
                     }
                 ]
             }
@@ -63,10 +50,9 @@
             {
                 "type": "RXT_orgPersonType",
                 "any_one_of": [
-                    "admin",
-                    "default",
-                    "user-admin",
-                    "tenant-access"
+                    "creator",
+                    "member",
+                    "reader"
                 ]
             }
         ]


### PR DESCRIPTION
This change addes fine grain rbac access when a user authenticates. This change maps all of the customers roles exposed by global auth to roles that we would expect to exist in OpenStack. This change updates the mapping file to ensure that no roles are defined by default. All roles are now dynamically applied upon authentication.

Mapping file example file change:

Users are permitted access when they have one of the following roles

* creator
* member
* observer

With this change, any role update made from the Rackspace management portal will be immediate made to shadow users within the OpenStack target environment.